### PR TITLE
removed unnecessary node packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
 node_modules/
+.vscode/

--- a/findmyparadise_frontend/package.json
+++ b/findmyparadise_frontend/package.json
@@ -9,13 +9,12 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "bootstrap": "^4.6.0",
     "bootstrap-vue": "^2.21.2",
     "core-js": "^3.6.5",
     "jquery": "^3.6.0",
     "smoothscroll-polyfill": "^0.4.4",
     "vue": "^3.0.7",
-    "vue2-datepicker": "^3.9.0",
+    "vue-axios": "^3.2.4",
     "vue3-datepicker": "^0.2.4"
   },
   "devDependencies": {
@@ -26,13 +25,9 @@
     "@vue/compiler-sfc": "^3.0.0",
     "@vue/eslint-config-prettier": "^6.0.0",
     "babel-eslint": "^10.1.0",
-    "bootstrap": "^4.5.2",
     "eslint": "^6.7.2",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vue": "^7.0.0",
-    "mutationobserver-shim": "^0.3.7",
-    "popper.js": "^1.16.1",
-    "portal-vue": "^2.1.7",
     "prettier": "^2.2.1",
     "sass": "^1.26.11",
     "sass-loader": "^10.0.2",


### PR DESCRIPTION
Removed bootstrap, portal-vue, vue2-datepicker, mutationobserver-shim, and popper.js dependencies because they were unnecessary.